### PR TITLE
Give more control and info about proxy requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,7 @@ dependencies {
 }
 
 compileKotlin {
-    kotlinOptions {
-        jvmTarget = '11'
-    }
+    kotlinOptions.jvmTarget = '11'
 }
 
 mainClassName = 'org.radarcns.gateway.MainKt'

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
 group 'org.radarcns'
 version '0.3.10-SNAPSHOT'
 
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 ext {
     githubRepoName = 'RADAR-Base/RADAR-Gateway'
@@ -68,7 +68,7 @@ dependencies {
 }
 
 compileKotlin {
-    kotlinOptions.jvmTarget = '11'
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
 }
 
 mainClassName = 'org.radarcns.gateway.MainKt'

--- a/src/main/kotlin/org/radarcns/gateway/Config.kt
+++ b/src/main/kotlin/org/radarcns/gateway/Config.kt
@@ -17,4 +17,5 @@ class Config {
     var jwtIssuer: String? = null
     var jwtResourceName: String = "res_gateway"
     var maxRequestSize: Long = 24*1024*1024
+    var maxRequests: Int = 200
 }

--- a/src/main/kotlin/org/radarcns/gateway/exception/GatewayTimeoutException.kt
+++ b/src/main/kotlin/org/radarcns/gateway/exception/GatewayTimeoutException.kt
@@ -1,0 +1,8 @@
+package org.radarcns.gateway.exception
+
+import org.radarcns.gateway.util.Json.jsonErrorResponse
+import javax.ws.rs.WebApplicationException
+import javax.ws.rs.core.Response.Status
+
+class GatewayTimeoutException(message: String) : WebApplicationException(
+        jsonErrorResponse(Status.BAD_GATEWAY, "gateway_timeout", message))

--- a/src/main/kotlin/org/radarcns/gateway/inject/GatewayResources.kt
+++ b/src/main/kotlin/org/radarcns/gateway/inject/GatewayResources.kt
@@ -1,5 +1,7 @@
 package org.radarcns.gateway.inject
 
+import okhttp3.ConnectionPool
+import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import org.glassfish.jersey.internal.inject.AbstractBinder
 import org.glassfish.jersey.internal.inject.PerThread
@@ -43,6 +45,11 @@ interface GatewayResources {
                     .readTimeout(1, TimeUnit.MINUTES)
                     .writeTimeout(1, TimeUnit.MINUTES)
                     .connectTimeout(10, TimeUnit.SECONDS)
+                    .dispatcher(Dispatcher().apply {
+                        maxRequests = config.maxRequests
+                        maxRequestsPerHost = config.maxRequests
+                    })
+                    .connectionPool(ConnectionPool(config.maxRequests, 5, TimeUnit.MINUTES))
                     .build())
                     .to(OkHttpClient::class.java)
 

--- a/src/main/kotlin/org/radarcns/gateway/io/ProxyClient.kt
+++ b/src/main/kotlin/org/radarcns/gateway/io/ProxyClient.kt
@@ -44,9 +44,10 @@ class ProxyClient(@Context config: Config, @Context private val client: OkHttpCl
         val response = try {
             client.newCall(request).execute()
         } catch (ex: SocketTimeoutException) {
-            throw GatewayTimeoutException("Connection to Kafka rest proxy timed out")
+            throw GatewayTimeoutException("Connection to Kafka REST proxy timed out")
         } catch (ex: IOException) {
-            throw BadGatewayException("Failed to connect to Kafka rest proxy")
+            logger.error("Failed to connecto to Kafka REST proxy: {}", ex.toString())
+            throw BadGatewayException("Failed to connect to Kafka REST proxy")
         }
 
         val didStart = AtomicBoolean(false)


### PR DESCRIPTION
Two tweaks to proxying requests:
- Make the number of simultaneous requests configurable (fixes #44)
- Make the HTTP status codes on connection failure less ambiguous