### PR TITLE
Have configuration to disable source-ID checks

### DIFF
--- a/gateway.yml
+++ b/gateway.yml
@@ -20,3 +20,6 @@ kafka:
 
 auth:
     managementPortalUrl: http://localhost:8080
+    # Whether to check that the user that submits data has the reported source ID registered
+    # in the ManagementPortal.
+    #checkSourceId: true

--- a/src/main/kotlin/org/radarbase/gateway/Config.kt
+++ b/src/main/kotlin/org/radarbase/gateway/Config.kt
@@ -25,6 +25,7 @@ data class KafkaConfig(
 
 data class AuthConfig(
         val resourceName: String = "res_gateway",
+        val checkSourceId: Boolean = true,
         val issuer: String? = null,
         val keyStore: KeyStoreConfig = KeyStoreConfig(),
         val publicKeys: KeyConfig = KeyConfig(),

--- a/src/main/kotlin/org/radarbase/gateway/io/AvroProcessor.kt
+++ b/src/main/kotlin/org/radarbase/gateway/io/AvroProcessor.kt
@@ -121,8 +121,13 @@ class AvroProcessor(
             }
         } ?: auth.defaultProject
 
-        auth.checkPermissionOnSource(Permission.MEASUREMENT_CREATE,
-                projectId, key["userId"]?.asText(), key["sourceId"]?.asText())
+        if (config.auth.checkSourceId) {
+            auth.checkPermissionOnSource(Permission.MEASUREMENT_CREATE,
+                    projectId, key["userId"]?.asText(), key["sourceId"]?.asText())
+        } else {
+            auth.checkPermissionOnSubject(Permission.MEASUREMENT_CREATE,
+                    projectId, key["userId"]?.asText())
+        }
 
         return keyMapping.jsonToAvro(key)
     }

--- a/src/main/kotlin/org/radarbase/gateway/io/BinaryToAvroConverter.kt
+++ b/src/main/kotlin/org/radarbase/gateway/io/BinaryToAvroConverter.kt
@@ -8,6 +8,7 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.avro.io.BinaryDecoder
 import org.apache.avro.io.Decoder
 import org.apache.avro.io.DecoderFactory
+import org.radarbase.gateway.Config
 import org.radarbase.jersey.auth.Auth
 import org.radarbase.jersey.exception.HttpInvalidContentException
 import org.radarbase.producer.rest.SchemaRetriever
@@ -19,7 +20,8 @@ import javax.ws.rs.core.Context
 /** Converts binary input from a RecordSet to Kafka JSON. */
 class BinaryToAvroConverter(
         @Context private val schemaRetriever: SchemaRetriever,
-        @Context private val auth: Auth) {
+        @Context private val auth: Auth,
+        @Context private val config: Config) {
 
     private var binaryDecoder: BinaryDecoder? = null
     private val readContext = ReadContext()
@@ -29,7 +31,7 @@ class BinaryToAvroConverter(
 
         binaryDecoder = decoder
 
-        val recordData = DecodedRecordData(topic, decoder, schemaRetriever, auth, readContext)
+        val recordData = DecodedRecordData(topic, decoder, schemaRetriever, auth, readContext, config.auth.checkSourceId)
 
         return AvroProcessingResult(
                 recordData.keySchemaMetadata.id,

--- a/src/main/kotlin/org/radarbase/gateway/io/DecodedRecordData.kt
+++ b/src/main/kotlin/org/radarbase/gateway/io/DecodedRecordData.kt
@@ -73,6 +73,8 @@ class DecodedRecordData(
             override fun hasNext() = remaining > 0
 
             override fun next(): GenericRecord {
+                if (!hasNext()) throw NoSuchElementException()
+
                 val result = readContext.decodeValue(decoder)
                 remaining--
                 if (remaining == 0) {

--- a/src/main/kotlin/org/radarbase/gateway/io/DecodedRecordData.kt
+++ b/src/main/kotlin/org/radarbase/gateway/io/DecodedRecordData.kt
@@ -16,7 +16,8 @@ class DecodedRecordData(
         private val decoder: BinaryDecoder,
         schemaRetriever: SchemaRetriever,
         auth: Auth,
-        private val readContext: BinaryToAvroConverter.ReadContext) : RecordData<GenericRecord, GenericRecord> {
+        private val readContext: BinaryToAvroConverter.ReadContext,
+        checkSources: Boolean) : RecordData<GenericRecord, GenericRecord> {
 
     private val key: GenericRecord
     private var size: Int
@@ -33,7 +34,11 @@ class DecodedRecordData(
         val userId = if (decoder.readIndex() == 1) decoder.readString() else auth.userId
         val sourceId = decoder.readString()
 
-        auth.checkPermissionOnSource(Permission.MEASUREMENT_CREATE, projectId, userId, sourceId)
+        if (checkSources) {
+            auth.checkPermissionOnSource(Permission.MEASUREMENT_CREATE, projectId, userId, sourceId)
+        } else {
+            auth.checkPermissionOnSubject(Permission.MEASUREMENT_CREATE, projectId, userId)
+        }
 
         remaining = decoder.readArrayStart().toInt()
         size = remaining

--- a/src/test/kotlin/org/radarbase/gateway/io/BinaryToAvroConverterTest.kt
+++ b/src/test/kotlin/org/radarbase/gateway/io/BinaryToAvroConverterTest.kt
@@ -9,6 +9,8 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.radarbase.data.AvroRecordData
+import org.radarbase.gateway.AuthConfig
+import org.radarbase.gateway.Config
 import org.radarbase.jersey.auth.Auth
 import org.radarbase.producer.rest.BinaryRecordRequest
 import org.radarbase.producer.rest.ParsedSchemaMetadata
@@ -57,7 +59,7 @@ class BinaryToAvroConverterTest {
 
             override fun hasRole(projectId: String, role: String) = true
         }
-        val converter = BinaryToAvroConverter(schemaRetriever, auth)
+        val converter = BinaryToAvroConverter(schemaRetriever, auth, Config())
 
         val genericKey = GenericRecordBuilder(ObservationKey.getClassSchema()).apply {
             this["projectId"] = "p"


### PR DESCRIPTION
This can simplify test setups to not dynamically register sources in the ManagementPortal.