### PR TITLE
0.7.0 snapshot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,8 +97,8 @@ jobs:
           # Use runtime labels from docker_meta as well as fixed labels
           labels: |
             ${{ steps.docker_meta.outputs.labels }}
-            maintainer=Joris Borgdorff <joris@thehyve.nl>
-            org.opencontainers.image.authors=Joris Borgdorff <joris@thehyve.nl>
+            maintainer=Bastiaan de Graaf <bastiaan@thehyve.nl>
+            org.opencontainers.image.authors=Bastiaan de Graaf <bastiaan@thehyve.nl>
             org.opencontainers.image.vendor=RADAR-base
             org.opencontainers.image.licenses=Apache-2.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,8 @@ jobs:
           # Use runtime labels from docker_meta as well as fixed labels
           labels: |
             ${{ steps.docker_meta.outputs.labels }}
-            maintainer=Joris Borgdorff <joris@thehyve.nl>
-            org.opencontainers.image.authors=Joris Borgdorff <joris@thehyve.nl>
+            maintainer=Bastiaan de Graaf <bastiaan@thehyve.nl>
+            org.opencontainers.image.authors=Bastiaan de Graaf <bastiaan@thehyve.nl>
             org.opencontainers.image.vendor=RADAR-base
             org.opencontainers.image.licenses=Apache-2.0
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,7 +7,7 @@ object Versions {
     const val dockerCompose = "0.17.5"
 
     const val ktor = "2.3.5"
-    const val radarJersey = "0.11.0"
+    const val radarJersey = "0.11.0-SNAPSHOT"
     const val radarCommons = "1.1.1"
     const val radarSchemas = "0.8.5"
     const val jackson = "2.15.2"


### PR DESCRIPTION
Bump radar jersey to 0.11.0-SNAPSHOT.

Update the maintainer and author lists in the github actions.