### PR TITLE
Fix redundant auth requests for JSON format topic uploads

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "0.7.4"
+    const val project = "0.7.5"
 
     const val java = 17
     const val kotlin = "1.9.22"

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/io/AvroRecordProcessor.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/io/AvroRecordProcessor.kt
@@ -66,8 +66,16 @@ class AvroRecordProcessor(
                 val entitiesChecked = HashSet<EntityDetails>()
 
                 for (entity in this) {
-                    // only check entities once
-                    if (!entitiesChecked.add(entity)) continue
+                    // Make sure to perform the permission check on entities only once.
+                    // Note:
+                    // There is a 'feature' around the comparison of EntityDetails objects; the checkPermissions method
+                    // updates the EntityDetails object with the organization id. This means that for effective comparison
+                    // we have to make copy of entity details so that the original entity details are compared. Without
+                    // this every entity processed here would be considered as an entity different from all previous and
+                    // would trigger a new permission check. This situation is a consequence of the later addition of the
+                    // concept of organization to the entity details.
+                    val entityCheck = entity.copy()
+                    if (!entitiesChecked.add(entityCheck)) continue
 
                     authService.checkPermission(
                         Permission.MEASUREMENT_CREATE,
@@ -160,6 +168,7 @@ class AvroRecordProcessor(
                     )
                     defaultProject
                 }
+
                 else -> jsonProject["string"]?.asText() ?: throw context.invalidContent(
                     "Project ID should be wrapped in string union type",
                 )


### PR DESCRIPTION
# Problem
When uploading data to kafka in JSON format gateway performs an authorization check for data elements. The caching mechanism that would prevent redundant checks on data elements with the same permission requirements is broken. This results in over-flooding of management portal with authorization requests, especially for bulk passive data such as accellerometer data.

# Cause
The caching strategy compares duplicate requests by comparing EntityDetails data objects. However, the checkPermissions method  mutates the EntityObjects as part of the evaluation (enhances it with the _organization id_). As a result, this makes every new EntityDetails object (that lacks an _organization id_) different from any previous instance, thereby always triggering a permission check.

# Solution
This PR solves the problem by using a copy of EntityDetails in the cache for comparison with new EntityDetails objects.