### PR TITLE
Impl. configuration of co-routine request timeouts

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "0.7.6"
+    const val project = "0.7.7"
 
     const val java = 17
     const val kotlin = "1.9.22"

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/GatewayServerConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/GatewayServerConfig.kt
@@ -13,6 +13,11 @@ data class GatewayServerConfig(
      */
     val maxRequestSize: Long = 24 * 1024 * 1024,
     /**
+     * Maximum time in seconds to wait for a request to complete.
+     * This timeout is applied to the co-routine context, not to the Grizzly server.
+     */
+    val requestTimeout: Int = 30,
+    /**
      * Whether JMX should be enabled. Disable if not needed, for higher performance.
      */
     val isJmxEnabled: Boolean = true,


### PR DESCRIPTION
# Problem
When uploading large files to Kafka concurrently, each request duration exceeds the default timeout of 30 seconds. This causes the service to return 503 http code when thought upload is proceeding correctly.

# Solution
This PR implements external configuration of the timeout duration for the REST endpoints. This will allow to configure longer timeout durations on systems where needed.