### PR TITLE
Fix enable Open Telemetry in radar-commons

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "0.9.0"
+    const val project = "0.9.1"
 
     const val java = 17
     const val kotlin = "1.9.22"

--- a/radar-gateway/build.gradle.kts
+++ b/radar-gateway/build.gradle.kts
@@ -101,4 +101,5 @@ radarKotlin {
     javaVersion.set(Versions.java)
     log4j2Version.set(Versions.log4j2)
     sentryEnabled.set(true)
+    openTelemetryAgentEnabled.set(true)
 }


### PR DESCRIPTION
the open telemetry jar was missing, which is fixed with this update