### PR TITLE
Fix: Environment variable access logic for config

### DIFF
--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/Main.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/Main.kt
@@ -19,6 +19,7 @@ fun main(args: Array<String>) {
             ),
             args,
         ).withDefaults()
+            .withEnv()
     } catch (ex: IllegalArgumentException) {
         logger.error("No configuration file was found.")
         logger.error("Usage: radar-gateway <config-file>")
@@ -27,7 +28,6 @@ fun main(args: Array<String>) {
 
     try {
         config.validate()
-        config.checkEnvironmentVars()
     } catch (ex: IllegalStateException) {
         logger.error("Configuration incomplete: {}", ex.message)
         exitProcess(1)

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/GatewayConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/GatewayConfig.kt
@@ -39,5 +39,4 @@ data class GatewayConfig(
             copy(s3 = it)
         },
     )
-
 }

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/GatewayConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/GatewayConfig.kt
@@ -1,6 +1,7 @@
 package org.radarbase.gateway.config
 
 import org.radarbase.gateway.inject.ManagementPortalEnhancerFactory
+import org.radarbase.jersey.config.ConfigLoader.copyOnChange
 import org.radarbase.jersey.enhancer.EnhancerFactory
 
 data class GatewayConfig(
@@ -29,7 +30,14 @@ data class GatewayConfig(
         auth.validate()
     }
 
-    fun checkEnvironmentVars() {
-        s3.checkEnvironmentVars()
-    }
+    fun withEnv(): GatewayConfig = this.copyOnChange(
+        s3,
+        {
+            it.withEnv()
+        },
+        {
+            copy(s3 = it)
+        },
+    )
+
 }

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StorageConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StorageConfig.kt
@@ -9,12 +9,12 @@ import org.radarbase.jersey.config.ConfigLoader.copyEnv
 import org.radarbase.jersey.config.ConfigLoader.copyOnChange
 
 data class S3StorageConfig(
-    var url: String? = null,
-    var accessKey: String? = null,
-    var secretKey: String? = null,
-    var bucketName: String? = null,
-    var region: String? = null,
-    var path: S3StoragePathConfig = S3StoragePathConfig(),
+    val url: String? = null,
+    val accessKey: String? = null,
+    val secretKey: String? = null,
+    val bucketName: String? = null,
+    val region: String? = null,
+    val path: S3StoragePathConfig = S3StoragePathConfig(),
 ) {
     fun withEnv(): S3StorageConfig = this
         .copyEnv(AWS_ENDPOINT_URL_S3) {

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StorageConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StorageConfig.kt
@@ -16,29 +16,18 @@ data class S3StorageConfig(
     val region: String? = null,
     val path: S3StoragePathConfig = S3StoragePathConfig(),
 ) {
-    fun withEnv(): S3StorageConfig = this
-        .copyEnv(AWS_ENDPOINT_URL_S3) {
+    fun withEnv(): S3StorageConfig = this.copyEnv(AWS_ENDPOINT_URL_S3) {
             copy(url = it)
-        }
-        .copyEnv(AWS_ACCESS_KEY_ID) {
+        }.copyEnv(AWS_ACCESS_KEY_ID) {
             copy(accessKey = it)
-        }
-        .copyEnv(AWS_SECRET_ACCESS_KEY) {
+        }.copyEnv(AWS_SECRET_ACCESS_KEY) {
             copy(secretKey = it)
-        }
-        .copyEnv(AWS_S3_BUCKET_NAME) {
+        }.copyEnv(AWS_S3_BUCKET_NAME) {
             copy(bucketName = it)
-        }
-        .copyEnv(AWS_DEFAULT_REGION) {
+        }.copyEnv(AWS_DEFAULT_REGION) {
             copy(region = it)
+        }.copyOnChange(path, S3StoragePathConfig::withEnv) {
+            copy(path = it)
         }
-        .copyOnChange(
-            path,
-            {
-                it.withEnv()
-            },
-            {
-                copy(path = it)
-            },
-        )
+
 }

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StorageConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StorageConfig.kt
@@ -5,6 +5,8 @@ import org.radarbase.gateway.utils.Env.AWS_DEFAULT_REGION
 import org.radarbase.gateway.utils.Env.AWS_ENDPOINT_URL_S3
 import org.radarbase.gateway.utils.Env.AWS_S3_BUCKET_NAME
 import org.radarbase.gateway.utils.Env.AWS_SECRET_ACCESS_KEY
+import org.radarbase.jersey.config.ConfigLoader.copyEnv
+import org.radarbase.jersey.config.ConfigLoader.copyOnChange
 
 data class S3StorageConfig(
     var url: String? = null,
@@ -14,22 +16,29 @@ data class S3StorageConfig(
     var region: String? = null,
     var path: S3StoragePathConfig = S3StoragePathConfig(),
 ) {
-    fun checkEnvironmentVars() {
-        url ?: run {
-            url = System.getenv(AWS_ENDPOINT_URL_S3)
+    fun withEnv(): S3StorageConfig = this
+        .copyEnv(AWS_ENDPOINT_URL_S3) {
+            copy(url = it)
         }
-        accessKey ?: run {
-            accessKey = System.getenv(AWS_ACCESS_KEY_ID)
+        .copyEnv(AWS_ACCESS_KEY_ID) {
+            copy(accessKey = it)
         }
-        secretKey ?: run {
-            secretKey = System.getenv(AWS_SECRET_ACCESS_KEY)
+        .copyEnv(AWS_SECRET_ACCESS_KEY) {
+            copy(secretKey = it)
         }
-        bucketName ?: run {
-            bucketName = System.getenv(AWS_S3_BUCKET_NAME)
+        .copyEnv(AWS_S3_BUCKET_NAME) {
+            copy(bucketName = it)
         }
-        region ?: run {
-            region = System.getenv(AWS_DEFAULT_REGION)
+        .copyEnv(AWS_DEFAULT_REGION) {
+            copy(region = it)
         }
-        path.checkEnvironmentVars()
-    }
+        .copyOnChange(
+            path,
+            {
+                it.withEnv()
+            },
+            {
+                copy(path = it)
+            },
+        )
 }

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StorageConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StorageConfig.kt
@@ -17,17 +17,16 @@ data class S3StorageConfig(
     val path: S3StoragePathConfig = S3StoragePathConfig(),
 ) {
     fun withEnv(): S3StorageConfig = this.copyEnv(AWS_ENDPOINT_URL_S3) {
-            copy(url = it)
-        }.copyEnv(AWS_ACCESS_KEY_ID) {
-            copy(accessKey = it)
-        }.copyEnv(AWS_SECRET_ACCESS_KEY) {
-            copy(secretKey = it)
-        }.copyEnv(AWS_S3_BUCKET_NAME) {
-            copy(bucketName = it)
-        }.copyEnv(AWS_DEFAULT_REGION) {
-            copy(region = it)
-        }.copyOnChange(path, S3StoragePathConfig::withEnv) {
-            copy(path = it)
-        }
-
+        copy(url = it)
+    }.copyEnv(AWS_ACCESS_KEY_ID) {
+        copy(accessKey = it)
+    }.copyEnv(AWS_SECRET_ACCESS_KEY) {
+        copy(secretKey = it)
+    }.copyEnv(AWS_S3_BUCKET_NAME) {
+        copy(bucketName = it)
+    }.copyEnv(AWS_DEFAULT_REGION) {
+        copy(region = it)
+    }.copyOnChange(path, S3StoragePathConfig::withEnv) {
+        copy(path = it)
+    }
 }

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StoragePathConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StoragePathConfig.kt
@@ -1,7 +1,6 @@
 package org.radarbase.gateway.config
 
 import org.radarbase.gateway.utils.Env.AWS_S3_BUCKET_NAME
-import org.radarbase.gateway.utils.Env.AWS_S3_PATH_PREFIX
 import org.radarbase.jersey.config.ConfigLoader.copyEnv
 
 data class S3StoragePathConfig(

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StoragePathConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StoragePathConfig.kt
@@ -1,6 +1,6 @@
 package org.radarbase.gateway.config
 
-import org.radarbase.gateway.utils.Env.AWS_S3_BUCKET_NAME
+import org.radarbase.gateway.utils.Env.AWS_S3_PATH_PREFIX
 import org.radarbase.jersey.config.ConfigLoader.copyEnv
 
 data class S3StoragePathConfig(
@@ -8,7 +8,7 @@ data class S3StoragePathConfig(
     val collectPerDay: Boolean = true,
 ) {
     fun withEnv(): S3StoragePathConfig = this
-        .copyEnv(AWS_S3_BUCKET_NAME) {
-            copy(prefix = prefix)
+        .copyEnv(AWS_S3_PATH_PREFIX) {
+            copy(prefix = it)
         }
 }

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StoragePathConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StoragePathConfig.kt
@@ -5,8 +5,8 @@ import org.radarbase.gateway.utils.Env.AWS_S3_PATH_PREFIX
 import org.radarbase.jersey.config.ConfigLoader.copyEnv
 
 data class S3StoragePathConfig(
-    var prefix: String? = null,
-    var collectPerDay: Boolean = true,
+    val prefix: String? = null,
+    val collectPerDay: Boolean = true,
 ) {
     fun withEnv(): S3StoragePathConfig = this
         .copyEnv(AWS_S3_BUCKET_NAME) {

--- a/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StoragePathConfig.kt
+++ b/radar-gateway/src/main/kotlin/org/radarbase/gateway/config/S3StoragePathConfig.kt
@@ -1,14 +1,15 @@
 package org.radarbase.gateway.config
 
+import org.radarbase.gateway.utils.Env.AWS_S3_BUCKET_NAME
 import org.radarbase.gateway.utils.Env.AWS_S3_PATH_PREFIX
+import org.radarbase.jersey.config.ConfigLoader.copyEnv
 
 data class S3StoragePathConfig(
     var prefix: String? = null,
     var collectPerDay: Boolean = true,
 ) {
-    fun checkEnvironmentVars() {
-        prefix ?: run {
-            prefix = System.getenv(AWS_S3_PATH_PREFIX)
+    fun withEnv(): S3StoragePathConfig = this
+        .copyEnv(AWS_S3_BUCKET_NAME) {
+            copy(prefix = prefix)
         }
-    }
 }


### PR DESCRIPTION
The config values are only read from environment variables if they are null. This doesn’t prioritize environment variables above local config values. The logic now uses the `radar-jersey` helper functions to prioritize environment variables over local configuration, checking the environment variables every time.